### PR TITLE
fix build for DMD v2.102.2; handle Ctrl-D, and exit more nicely

### DIFF
--- a/source/orelang/Interpreter.d
+++ b/source/orelang/Interpreter.d
@@ -71,7 +71,8 @@ class Interpreter {
     while (true) {
       string input = readln.chomp;
 
-      if (input == "exit" || input == "(exit)") {
+      if (stdin.eof() || input == "exit" || input == "(exit)") {  // stdin.eof() for Ctrl-D
+        writeln("bye!");  // print newline, so do not mess up the screen
         break;
       }
 

--- a/source/orelang/operator/SystemOperator.d
+++ b/source/orelang/operator/SystemOperator.d
@@ -21,7 +21,7 @@ class SystemOperator : IOperator {
       auto pid = spawnProcess(args_strs);//execute(args_strs.join(" "));
 
       return new Value(wait(pid));
-    } catch {
+    } catch (Throwable) {
       return new Value(-1);
     }
   }


### PR DESCRIPTION
without checking `stdin.eof()`, when the user press `Ctrl-D`, it will result in endless loop:

=> => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => => 
....

